### PR TITLE
Remove starting and trailing slashes from existing CUR output prefix

### DIFF
--- a/cloudformation/coast-cfn.yaml
+++ b/cloudformation/coast-cfn.yaml
@@ -119,7 +119,7 @@ Resources:
                             cur_report['time_unit'] = report['TimeUnit']
                             cur_report['format'] = report['Format']
                             cur_report['output_bucket'] = report['S3Bucket']
-                            cur_report['output_prefix'] = report['S3Prefix']
+                            cur_report['output_prefix'] = report['S3Prefix'].strip('/')
                             cur_report['region'] = report['S3Region']
                             cur_report['AdditionalSchemaElements'] = report['AdditionalSchemaElements']
                             break


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/coast-grafana-cost-intelligence-dashboards/issues/12

*Description of changes:* Apply `strip('/')` to the output prefix of existing CUR, removing starting and trailing slashes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
