### PR TITLE
Added delete workgroup option; added additional logging option

### DIFF
--- a/cloudformation/coast-cfn.yaml
+++ b/cloudformation/coast-cfn.yaml
@@ -705,6 +705,7 @@ Resources:
           - - 'coast-workgroup-'
             - !Ref AWS::StackName
       Description: 'Used for COAST'
+      RecursiveDeleteOption: true
       Tags:
         - Key: "GrafanaDataSource"
           Value: "false"
@@ -712,6 +713,7 @@ Resources:
           Value: "coast"
       WorkGroupConfiguration:
         EnforceWorkGroupConfiguration: true
+        PublishCloudWatchMetricsEnabled: true
         ResultConfiguration:
           EncryptionConfiguration:
             EncryptionOption: SSE_S3


### PR DESCRIPTION
*Issue: https://github.com/aws-samples/coast-grafana-cost-intelligence-dashboards/issues/9


Description of changes: 

- Added recursive delete for Athena Workgroup, to solve CFN delete resource issue
- Added PublishCloudWatchMetricsEnabled to push additional Cloudwatch metrics which is useful for the Cost of Coast dashboard



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
